### PR TITLE
Refactor entire interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,33 +5,33 @@ equals allows you to assert certain equality constraints between python objects 
 
 strings:
 -------
-    contains('abc') == '123 abc 456'
-    startswith('abc') == 'abcdef'
-    endswith('abc') == '123abc'
-    matches('^abc$') == 'abc'
+    any_string.containing('abc') == '123 abc 456'
+    any_string.starting_with('abc') == 'abcdef'
+    any_string.ending_with('abc') == '123abc'
+    any_string.matching('^abc$') == 'abc'
 
 
 numbers:
 -------
-    less_than(5) == 4
-    less_than_or_equal(5) == 5
-    greater_than(4) == 5
-    greater_than_or_equal(5) == 5
-    between(1, 3) == 2
-    plus_or_minus(10, 1) == 10.5
+    any_number.less_than(5) == 4
+    any_number.less_than_or_equal(5) == 5
+    any_number.greater_than(4) == 5
+    any_number.greater_than_or_equal(5) == 5
+    any_number.between(1, 3) == 2
+    any_number.plus_or_minus(10, 1) == 10.5
 
 dictionaries:
 -------
-    has_keys(1, 2) == {1: 2, 2:3, 4:5}
-    has_elements(foo='bar') == {
+    any_dict.with_keys(1, 2) == {1: 2, 2:3, 4:5}
+    any_dict.containing(foo='bar') == {
         'foo': 'bar',
         'bob': 'barker'
     }
 
 iterators:
 -------
-    has_elements(1, 2, 3) == [1, 2, 3, 4, 5]
-    same_elements(1, 2, 3) == [2, 3, 1]
+    any_iter.containing(1, 2, 3) == [1, 2, 3, 4, 5]
+    any_iter.containing_only(1, 2, 3) == [2, 3, 1]
 
 objects:
 -------
@@ -50,12 +50,12 @@ Usage with Mock:
 -------
     test_object = Mock()
     test_object.method({'bob': 'barker'})
-    test_object.method.assert_called_with(instance_of(dict))
+    test_object.method.assert_called_with(any_dict)
 
 Usage with doubles:
 -------
     test_object = TestClass()
-    expect(test_object).method.with_args(contains('bob'))
+    expect(test_object).method.with_args(any_string.containing('bob'))
 
     test_object.method('bob barker')
 

--- a/equals/__init__.py
+++ b/equals/__init__.py
@@ -1,31 +1,18 @@
-from string_matchers import StringContainsMatcher as contains  # noqa
-from string_matchers import StringStartsWithMatcher as startswith  # noqa
-from string_matchers import StringEndsWithMatcher as endswith  # noqa
-from string_matchers import StringRegexMatcher as matches  # noqa
+import numbers
+import collections
 
-from iter_matchers import SameElements as same_elements  # noqa
-from dict_matchers import HasKeys as has_keys  # noqa
-import iter_matchers
-import dict_matchers
+from instance_of import InstanceOf as instance_of
+from object_matchers import AnythingTruthy
+from object_matchers import AnythingFalsey
 
-from object_matchers import MatchAnything
-from object_matchers import MatchAnythingTruthy
-from object_matchers import MatchAnythingFalsey
-from object_matchers import MatchAnyInstanceOf as instance_of  # noqa
-
-from number_matchers import LessThan as less_than  # noqa
-from number_matchers import LessThanOrEqual as less_than_or_equal  # noqa
-from number_matchers import GreaterThan as greater_than  # noqa
-from number_matchers import GreaterThanOrEqual as greater_than_or_equal  # noqa
-from number_matchers import WithinRange as between  # noqa
-from number_matchers import PlusOrMinus as plus_or_minus  # noqa
-
-anything = MatchAnything()
-anything_false = MatchAnythingFalsey()
-anything_true = MatchAnythingTruthy()
-
-
-def has_elements(*args, **kwargs):
-    if kwargs:
-        return dict_matchers.Includes(**kwargs)
-    return iter_matchers.Includes(*args)
+anything = instance_of()
+any_string = instance_of(basestring)
+any_number = instance_of(numbers.Number)
+any_int = instance_of(int)
+any_float = instance_of(float)
+any_iterable = instance_of(collections.Iterable)
+any_dict = instance_of(dict)
+any_list = instance_of(list)
+any_tuple = instance_of(tuple)
+anything_false = AnythingFalsey(anything)
+anything_true = AnythingTruthy(anything)

--- a/equals/base_matcher.py
+++ b/equals/base_matcher.py
@@ -1,8 +1,23 @@
-class BaseMatcher(object):
+from constraints import Constraints
 
-    def __init__(self, *args, **kwargs):
+
+class BaseMatcher(Constraints):
+    def __init__(self, parent, *args, **kwargs):
+        self._parent = parent
         self.args = args
         self.kwargs = kwargs
+        self._handle_args(*args, **kwargs)
 
     def __eq__(self, value):
-        return self._check(value)
+        if value != self._parent:
+            return False
+        try:
+            return self._check(value)
+        except Exception:
+            return False
+
+    def __ne__(self, value):
+        return not self == value
+
+    def _handle_args(self, *args, **kwargs):
+        pass

--- a/equals/constraints.py
+++ b/equals/constraints.py
@@ -1,0 +1,87 @@
+from functools import wraps
+
+
+def constraint(func):
+    @wraps(func)
+    def wrapped(self, *args, **kwargs):
+        matcher_class = func(self)
+        value = matcher_class(
+            self,
+            *args,
+            **kwargs
+        )
+        return value
+
+    return wrapped
+
+
+class Constraints(object):
+    @constraint
+    def containing(self):
+        from iter_matchers import Containing
+        return Containing
+
+    @constraint
+    def not_containing(self):
+        from iter_matchers import NotContaining
+        return NotContaining
+
+    @constraint
+    def matching(self):
+        from string_matchers import RegexMatcher
+        return RegexMatcher
+
+    @constraint
+    def containing_only(self):
+        from iter_matchers import ContainingOnly
+        return ContainingOnly
+
+    @constraint
+    def starting_with(self):
+        from string_matchers import StartsWithMatcher
+        return StartsWithMatcher
+
+    @constraint
+    def ending_with(self):
+        from string_matchers import EndsWithMatcher
+        return EndsWithMatcher
+
+    @constraint
+    def with_attrs(self):
+        from object_matchers import HasAttrs
+        return HasAttrs
+
+    @constraint
+    def greater_than(self):
+        from number_matchers import GreaterThan
+        return GreaterThan
+
+    @constraint
+    def greater_than_or_equal_to(self):
+        from number_matchers import GreaterThanOrEqual
+        return GreaterThanOrEqual
+
+    @constraint
+    def less_than(self):
+        from number_matchers import LessThan
+        return LessThan
+
+    @constraint
+    def less_than_or_equal_to(self):
+        from number_matchers import LessThanOrEqual
+        return LessThanOrEqual
+
+    @constraint
+    def between(self):
+        from number_matchers import WithinRange
+        return WithinRange
+
+    @constraint
+    def plus_or_minus(self):
+        from number_matchers import PlusOrMinus
+        return PlusOrMinus
+
+    @constraint
+    def with_keys(self):
+        from dict_matchers import HasKeys
+        return HasKeys

--- a/equals/dict_matchers.py
+++ b/equals/dict_matchers.py
@@ -1,19 +1,7 @@
 from base_matcher import BaseMatcher
 
 
-class DictMatcher(BaseMatcher):
-    pass
-
-
-class Includes(DictMatcher):
-    def _check(self, value):
-        for k, v in self.kwargs.items():
-            if k not in value or not value[k] == v:
-                return False
-        return True
-
-
-class HasKeys(DictMatcher):
+class HasKeys(BaseMatcher):
     def _check(self, value):
         for i in self.args:
             if i not in value:

--- a/equals/instance_of.py
+++ b/equals/instance_of.py
@@ -1,0 +1,16 @@
+from constraints import Constraints
+
+
+class InstanceOf(Constraints):
+    _types = None
+
+    def __init__(self, *types):
+        self._types = types
+
+    def __eq__(self, value):
+        if not self._types:
+            return True
+        return isinstance(value, self._types)
+
+    def __ne__(self, value):
+        return not self == value

--- a/equals/iter_matchers.py
+++ b/equals/iter_matchers.py
@@ -1,20 +1,36 @@
 from base_matcher import BaseMatcher
 
 
-class IteratorMatcher(BaseMatcher):
-    pass
-
-
-class Includes(IteratorMatcher):
+class Containing(BaseMatcher):
     def _check(self, value):
+        # This will check list like objects
         for v in self.args:
             if v not in value:
+                return False
+
+        # This will check dictionary like objects
+        for k, v in self.kwargs.items():
+            if k not in value or not value[k] == v:
                 return False
         return True
 
 
-class SameElements(Includes):
+class NotContaining(Containing):
+    def _check(self, value):
+        # This will check list like objects
+        for v in self.args:
+            if v in value:
+                return False
+
+        # This will check dictionary like objects
+        for k, v in self.kwargs.items():
+            if k in value and value[k] == v:
+                return False
+        return True
+
+
+class ContainingOnly(Containing):
     def _check(self, value):
         if not len(value) == len(self.args):
             return False
-        return super(SameElements, self)._check(value)
+        return super(ContainingOnly, self)._check(value)

--- a/equals/number_matchers.py
+++ b/equals/number_matchers.py
@@ -2,7 +2,7 @@ from base_matcher import BaseMatcher
 
 
 class NumberMatcher(BaseMatcher):
-    def __init__(self, value):
+    def _handle_args(self, value):
         self.value = value
 
 
@@ -27,7 +27,7 @@ class GreaterThanOrEqual(NumberMatcher):
 
 
 class WithinRange(NumberMatcher):
-    def __init__(self, min_val, max_val):
+    def _handle_args(self, min_val, max_val):
         self.min_val = min_val
         self.max_val = max_val
 
@@ -36,8 +36,8 @@ class WithinRange(NumberMatcher):
 
 
 class PlusOrMinus(WithinRange):
-    def __init__(self, value, error):
-        super(PlusOrMinus, self).__init__(
+    def _handle_args(self, value, error):
+        super(PlusOrMinus, self)._handle_args(
             value - error,
             value + error,
         )

--- a/equals/object_matchers.py
+++ b/equals/object_matchers.py
@@ -1,40 +1,23 @@
 from base_matcher import BaseMatcher
 
 
-class Matcher(BaseMatcher):
-
-    def with_attrs(self, **kwargs):
-        return MatchHasAttrs(
-            *self.args,
-            **kwargs
-        )
-
-
-class MatchAnything(Matcher):
-    def _check(self, value):
-        return True
-
-
-class MatchAnythingTruthy(Matcher):
+class AnythingTruthy(BaseMatcher):
     def _check(self, value):
         return bool(value)
 
 
-class MatchAnythingFalsey(Matcher):
+class AnythingFalsey(BaseMatcher):
     def _check(self, value):
         return not bool(value)
 
 
-class MatchAnyInstanceOf(Matcher):
+class AnyInstanceOf(BaseMatcher):
     def _check(self, value):
         return isinstance(value, self.args)
 
 
-class MatchHasAttrs(Matcher):
+class HasAttrs(BaseMatcher):
     def _check(self, value):
-        if self._wrong_type(value):
-            return False
-
         for k, v in self.kwargs.items():
             if not hasattr(value, k):
                 return False
@@ -42,9 +25,3 @@ class MatchHasAttrs(Matcher):
                 return False
 
         return True
-
-    def _wrong_type(self, value):
-        if not self.args:
-            return False
-
-        return not isinstance(value, self.args)

--- a/equals/string_matchers.py
+++ b/equals/string_matchers.py
@@ -4,25 +4,20 @@ from base_matcher import BaseMatcher
 
 
 class StringMatcher(BaseMatcher):
-    def __init__(self, value):
+    def _handle_args(self, value):
         self.value = value
 
 
-class StringContainsMatcher(StringMatcher):
-    def _check(self, value):
-        return self.value in value
-
-
-class StringStartsWithMatcher(StringMatcher):
+class StartsWithMatcher(StringMatcher):
     def _check(self, value):
         return value.startswith(self.value)
 
 
-class StringEndsWithMatcher(StringMatcher):
+class EndsWithMatcher(StringMatcher):
     def _check(self, value):
         return value.endswith(self.value)
 
 
-class StringRegexMatcher(StringMatcher):
+class RegexMatcher(StringMatcher):
     def _check(self, value):
         return bool(re.search(self.value, value))

--- a/test/dictionary_test.py
+++ b/test/dictionary_test.py
@@ -1,26 +1,26 @@
-from equals import has_elements, has_keys
+from equals import any_dict
 
 
 def test_has_elements_passes_on_super_set():
-    assert has_elements(foo='bar') == {
+    assert any_dict.containing(foo='bar') == {
         'foo': 'bar',
         'bob': 'barker',
     }
 
 
 def test_has_elements_fails_on_sub_set():
-    assert not has_elements(foo='bar') == {'bob': 'barker'}
+    assert not any_dict.containing(foo='bar') == {'bob': 'barker'}
 
 
 def hest_has_keys_passes_on_dict_with_exact_keys():
-    assert has_keys('foo', 'bob') == {
+    assert any_dict.containing('foo', 'bob') == {
         'foo': 'bar',
         'bob': 'barker',
     }
 
 
 def hest_has_keys_passes_on_dict_with_extra_keys():
-    assert has_keys('foo', 'bob') == {
+    assert any_dict.containing('foo', 'bob') == {
         'foo': 'bar',
         'bob': 'barker',
         'ricky': 'bobby',
@@ -28,8 +28,8 @@ def hest_has_keys_passes_on_dict_with_extra_keys():
 
 
 def test_has_fails_on_dict_with_missing_keys():
-    assert not has_keys('foo', 'bob') == {'bob': 'barker'}
+    assert not any_dict.with_keys('foo', 'bob') == {'bob': 'barker'}
 
 
 def test_order_of_test_does_not_matter():
-    assert {'foo': 'bar'} == has_elements(foo='bar')
+    assert {'foo': 'bar'} == any_dict.containing(foo='bar')

--- a/test/doubles_integration_test.py
+++ b/test/doubles_integration_test.py
@@ -2,7 +2,7 @@ from doubles import expect, allow
 from doubles.exceptions import UnallowedMethodCallError
 import pytest
 
-from equals import contains
+from equals import any_string
 
 
 class TestClass(object):
@@ -12,14 +12,18 @@ class TestClass(object):
 
 def test_expect_passes():
     test_object = TestClass()
-    expect(test_object).method.with_args(contains('bob'))
+    expect(test_object).method.with_args(
+        any_string.containing('bob')
+    )
 
     test_object.method('bob barker')
 
 
 def test_allow_can_fail():
     test_object = TestClass()
-    allow(test_object).method.with_args(contains('foobar'))
+    allow(test_object).method.with_args(
+        any_string.containing('todd')
+    )
 
     with pytest.raises(UnallowedMethodCallError):
         test_object.method('bob barker')

--- a/test/iterator_test.py
+++ b/test/iterator_test.py
@@ -1,25 +1,33 @@
-from equals import has_elements, same_elements
+from equals import any_iterable
 
 
-def test_has_elements_passes_on_super_set():
-    assert has_elements(1, 2, 3) == [1, 2, 3, 4, 5]
+def test_containing_passes_on_super_set():
+    assert any_iterable.containing(1, 2, 3) == [1, 2, 3, 4, 5]
 
 
-def test_has_elements_fails_on_sub_set():
-    assert not has_elements(1, 2, 3) == [2, 3, 4, 5]
+def test_containing_fails_on_sub_set():
+    assert not any_iterable.containing(1, 2, 3) == [2, 3, 4, 5]
 
 
-def test_same_elements_passes_on_identical_list():
-    assert same_elements(1, 2, 3) == [1, 2, 3]
+def test_not_containing_passes_if_value_is_not_found():
+    assert any_iterable.not_containing(1, 2, 3) == [4, 5]
 
 
-def test_same_elements_fails_on_super_set():
-    assert not same_elements(1, 2, 3) == [1, 2, 3, 4]
+def test_not_containing_fails_if_value_is_found():
+    assert not any_iterable.not_containing(1, 2, 3) == [1, 2, 3, 4, 5]
 
 
-def test_same_elements_fails_on_sub_set():
-    assert not same_elements(1, 2, 3) == [2, 3]
+def test_containing_only_passes_on_identical_list():
+    assert any_iterable.containing_only(1, 2, 3) == [1, 2, 3]
+
+
+def test_containing_only_fails_on_super_set():
+    assert not any_iterable.containing_only(1, 2, 3) == [1, 2, 3, 4]
+
+
+def test_containing_only_fails_on_sub_set():
+    assert not any_iterable.containing_only(1, 2, 3) == [2, 3]
 
 
 def test_order_of_test_does_not_matter():
-    assert [1, 2, 3, 4, 5] == has_elements(1, 2, 3)
+    assert [1, 2, 3, 4, 5] == any_iterable.containing(1, 2, 3)

--- a/test/number_test.py
+++ b/test/number_test.py
@@ -1,95 +1,88 @@
-from equals import (
-    less_than,
-    less_than_or_equal,
-    greater_than,
-    greater_than_or_equal,
-    between,
-    plus_or_minus,
-)
+from equals import any_number
 
 
 class TestLessThan(object):
     def test_equals_a_smaller_number(self):
-        assert less_than(5) == 4
+        assert any_number.less_than(5) == 4
 
     def test_does_not_equal_same_number(self):
-        assert not less_than(5) == 5
+        assert not any_number.less_than(5) == 5
 
     def test_does_not_equal_larger_number(self):
-        assert not less_than(5) == 6
+        assert not any_number.less_than(5) == 6
 
     def test_order_of_test_does_not_matter(self):
-        assert 4 == less_than(5)
+        assert 4 == any_number.less_than(5)
 
 
 class TestGreateThan(object):
     def test_equals_a_larger_number(self):
-        assert greater_than(5) == 6
+        assert any_number.greater_than(5) == 6
 
     def test_does_not_equal_same_number(self):
-        assert not greater_than(5) == 5
+        assert not any_number.greater_than(5) == 5
 
     def test_does_not_equal_smaller_number(self):
-        assert not greater_than(5) == 4
+        assert not any_number.greater_than(5) == 4
 
     def test_order_of_test_does_not_matter(self):
-        assert 6 == greater_than(5)
+        assert 6 == any_number.greater_than(5)
 
 
 class TestLessThanOrEqual(object):
     def test_equal_equals_a_smaller_number(self):
-        assert less_than_or_equal(5) == 4
+        assert any_number.less_than_or_equal_to(5) == 4
 
     def test_equals_same_number(self):
-        assert less_than_or_equal(5) == 5
+        assert any_number.less_than_or_equal_to(5) == 5
 
     def test_does_not_equal_larger_number(self):
-        assert not less_than_or_equal(5) == 6
+        assert not any_number.less_than_or_equal_to(5) == 6
 
     def test_order_of_test_does_not_matter(self):
-        assert 4 == less_than_or_equal(5)
+        assert 4 == any_number.less_than_or_equal_to(5)
 
 
 class TestGreateThanOrEqual(object):
     def test_equals_a_larger_number(self):
-        assert greater_than_or_equal(5) == 6
+        assert any_number.greater_than_or_equal_to(5) == 6
 
     def test_equals_same_number(self):
-        assert greater_than_or_equal(5) == 5
+        assert any_number.greater_than_or_equal_to(5) == 5
 
     def test_does_not_equal_smaller_number(self):
-        assert not greater_than_or_equal(5) == 4
+        assert not any_number.greater_than_or_equal_to(5) == 4
 
     def test_order_of_test_does_not_matter(self):
-        assert 6 == greater_than_or_equal(5)
+        assert 6 == any_number.greater_than_or_equal_to(5)
 
 
 class TestBetween(object):
     def test_equals_value_in_range(self):
-        assert between(1, 3) == 2
+        assert any_number.between(1, 3) == 2
 
     def test_does_not_equal_value_larger_than_max(self):
-        assert not between(1, 3) == 4
+        assert not any_number.between(1, 3) == 4
 
     def test_does_not_equal_value_smaller_than_min(self):
-        assert not between(1, 3) == 0
+        assert not any_number.between(1, 3) == 0
 
     def test_does_not_equal_value_equal_to_max(self):
-        assert not between(1, 3) == 3
+        assert not any_number.between(1, 3) == 3
 
     def test_does_not_equal_value_equal_to_min(self):
-        assert not between(1, 3) == 1
+        assert not any_number.between(1, 3) == 1
 
     def test_order_of_test_does_not_matter(self):
-        assert 2 == between(1, 3)
+        assert 2 == any_number.between(1, 3)
 
 
 class TestPlusOrMinus(object):
     def test_equals_value_within_range(self):
-        assert plus_or_minus(10, 1) == 10.5
+        assert any_number.plus_or_minus(10, 1) == 10.5
 
     def test_does_not_eqaul_value_out_of_range(self):
-        assert not plus_or_minus(10, 1) == 11.5
+        assert not any_number.plus_or_minus(10, 1) == 11.5
 
     def test_order_of_test_does_not_matter(self):
-        assert 10.5 == plus_or_minus(10, 1)
+        assert 10.5 == any_number.plus_or_minus(10, 1)

--- a/test/string_test.py
+++ b/test/string_test.py
@@ -1,37 +1,45 @@
-from equals import contains, startswith, endswith, matches
+from equals import any_string
 
 
 def test_string_contains_substring():
-    assert contains('abc') == '123 abc 456'
+    assert any_string.containing('abc') == '123 abc 456'
 
 
 def test_string_does_not_contain_substring():
-    assert not contains('ac') == '123 abc 456'
+    assert not any_string.containing('ac') == '123 abc 456'
 
 
 def test_string_startswith_substring():
-    assert startswith('abc') == 'abcdef'
+    assert any_string.starting_with('abc') == 'abcdef'
 
 
 def test_string_does_not_startswith_substring():
-    assert not startswith('bc') == 'abcdef'
+    assert not any_string.starting_with('bc') == 'abcdef'
 
 
 def test_string_endswith_substring():
-    assert endswith('abc') == '123abc'
+    assert any_string.ending_with('abc') == '123abc'
 
 
 def test_string_does_not_endswith_substring():
-    assert not endswith('ab') == '123abc'
+    assert not any_string.ending_with('ab') == '123abc'
 
 
 def test_string_matches_regex():
-    assert matches('^abc$') == 'abc'
+    assert any_string.matching('^abc$') == 'abc'
 
 
 def test_string_does_not_match_regex():
-    assert not matches('^bc$') == 'abc'
+    assert not any_string.matching('^bc$') == 'abc'
 
 
 def test_order_of_test_does_not_matter():
-    assert '123 abc 456' == contains('abc')
+    assert '123 abc 456' == any_string.containing('abc')
+
+
+def test_with_no_constraints_pass_case():
+    assert any_string == 'bob barker'
+
+
+def test_with_no_constraints_fail_case():
+    assert not any_string == 1


### PR DESCRIPTION
- Instead of doing contains('foo') now do anything.containing('foo') or
- if you want to limit it to a string do any_string.containing('foo')
- Add more type specific matchers any_number, any_iterable, any_list
- etc.
- Allow chaining e.g. any_number.greater_than(4).less_than(10)
